### PR TITLE
added ocpVersion to values.yaml

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -7,6 +7,7 @@ global:
   pullSecret: null
 hubconfig:
   nodeSelector: null
+  ocpVersion: 4.12.0
   proxyConfigs: {}
   replicaCount: 1
   tolerations: []


### PR DESCRIPTION
In MCH, when we render charts we depend on checking the `ocpVersion` when adding details related to the `seccompProfile` type for deployment manifeset.