### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for cluster-permission-acm-214

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -16,7 +16,8 @@ ENV OPERATOR=/usr/local/bin/cluster-permission \
     USER_NAME=cluster-permission
 
 LABEL \
-    name="cluster-permission" \
+    name="rhacm2/acm-cluster-permission-rhel9" \
+    cpe="cpe:/a:redhat:acm:2.14::el9" \
     com.redhat.component="cluster-permission" \
     description="Cluster permission controller" \
     maintainer="acm-contact@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
