### PR TITLE
Replace legacy kubebuilder-tools download with sdk-go envtest setup [release-2.16]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dylib
 bin
 testbin/*
+_output/
 Dockerfile.cross
 vendor/*
 

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,9 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/open-cluster-management/cluster-permission:latest
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.26.0
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
 
 export CGO_ENABLED=1
-
-TEST_TMP :=/tmp
-export KUBEBUILDER_ASSETS ?=$(TEST_TMP)/kubebuilder/bin
-K8S_VERSION ?=1.24.1
-GOHOSTOS ?=$(shell go env GOHOSTOS)
-GOHOSTARCH ?= $(shell go env GOHOSTARCH)
-KB_TOOLS_ARCHIVE_NAME :=kubebuilder-tools-$(K8S_VERSION)-$(GOHOSTOS)-$(GOHOSTARCH).tar.gz
-KB_TOOLS_ARCHIVE_PATH := $(TEST_TMP)/$(KB_TOOLS_ARCHIVE_NAME)
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -139,8 +130,6 @@ $(LOCALBIN):
 ## Tool Binaries
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-ENVTEST ?= $(LOCALBIN)/setup-envtest
-
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.8.7
 CONTROLLER_TOOLS_VERSION ?= v0.17.1
@@ -161,21 +150,13 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
 	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
 .PHONY: test
-
-# download the kubebuilder-tools to get kube-apiserver binaries from it
-ensure-kubebuilder-tools:
-ifeq "" "$(wildcard $(KUBEBUILDER_ASSETS))"
-	$(info Downloading kube-apiserver into '$(KUBEBUILDER_ASSETS)')
-	mkdir -p '$(KUBEBUILDER_ASSETS)'
-	curl -s -f -L https://storage.googleapis.com/kubebuilder-tools/$(KB_TOOLS_ARCHIVE_NAME) -o '$(KB_TOOLS_ARCHIVE_PATH)'
-	tar -C '$(KUBEBUILDER_ASSETS)' --strip-components=2 -zvxf '$(KB_TOOLS_ARCHIVE_PATH)'
-else
-	$(info Using existing kube-apiserver from "$(KUBEBUILDER_ASSETS)")
-endif
-.PHONY: ensure-kubebuilder-tools
-
-test: ensure-kubebuilder-tools
+test: envtest-setup
 	go test -timeout 300s -v ./controllers/... -coverprofile=coverage.out
 
 .PHONY: deploy-ocm

--- a/controllers/clusterpermission_controller_test.go
+++ b/controllers/clusterpermission_controller_test.go
@@ -672,7 +672,7 @@ var _ = Describe("ClusterPermission controller", func() {
 				},
 			}))).Should(Equal(1))
 
-			By("Create ClusterPermission with ClusterRoleBinding that has no subject or subjects")
+			By("Create ClusterPermission with ClusterRoleBinding that has no subject or subjects - should be rejected by XValidation")
 			clusterPermissionMissingSubjectSubjects := cpv1alpha1.ClusterPermission{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "clusterpermission-no-subject-subjects",
@@ -690,7 +690,7 @@ var _ = Describe("ClusterPermission controller", func() {
 				},
 			}
 
-			Expect(k8sClient.Create(ctx, &clusterPermissionMissingSubjectSubjects)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, &clusterPermissionMissingSubjectSubjects)).ShouldNot(Succeed())
 
 			By("Create ClusterPermission with Role and ClusterRole that doesn't exist validate should have error status")
 			clusterPermissionRoleClusterRoleNotExistValidate := cpv1alpha1.ClusterPermission{


### PR DESCRIPTION
## Summary

- **Replaced** the deprecated `storage.googleapis.com/kubebuilder-tools` download method with the automated `ensure-envtest.sh` script from [open-cluster-management-io/sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md)
- **Removed** legacy Makefile variables (`ENVTEST_K8S_VERSION`, `K8S_VERSION`, `KUBEBUILDER_ASSETS`, `TEST_TMP`, `GOHOSTOS`, `GOHOSTARCH`, `KB_TOOLS_ARCHIVE_NAME`, `KB_TOOLS_ARCHIVE_PATH`) and the `ensure-kubebuilder-tools` target
- **Added** new `envtest-setup` reusable Makefile target that auto-detects K8s and setup-envtest versions from `go.mod`
- **Added** `_output/` to `.gitignore` (envtest binary cache directory)
- **Fixed** unit test that incorrectly expected `k8sClient.Create()` to succeed for a `ClusterPermission` with empty subjects in `ClusterRoleBinding` — the CRD's CEL XValidation rule correctly rejects this, and newer envtest (K8s 1.31+) now enforces it

## Motivation

The old approach manually downloaded kubebuilder-tools from a deprecated GCS bucket (`storage.googleapis.com/kubebuilder-tools`) with hardcoded K8s version `1.24.1`. The new sdk-go `ensure-envtest.sh` script:

1. Auto-detects K8s version from `go.mod` (`k8s.io/api v0.X.Y` → `1.X.Y`)
2. Auto-detects setup-envtest branch from `go.mod` (`controller-runtime v0.X.Y` → `release-0.X`)
3. Includes a three-tier version fallback strategy (exact → minor wildcard → latest)
4. Enforces minimum `setup-envtest` version `release-0.19` (uses GitHub releases index instead of deprecated GCS bucket)
5. Requires zero manual version configuration — versions stay in sync with `go.mod` dependencies

## Test plan

- [x] Verify `make test` runs successfully with the new `envtest-setup` target
- [x] Verify envtest binaries are downloaded to `_output/tools/bin/`
- [x] Verify `KUBEBUILDER_ASSETS` is correctly exported for test execution
- [x] Verify unit test fix: assertion changed from `Should(Succeed())` to `ShouldNot(Succeed())` for XValidation rejection test
- [ ] Confirm CI pipeline passes with the updated Makefile

🤖 Generated with [Claude Code](https://claude.com/claude-code)