### PR TITLE
Fix unit test to expect XValidation rejection for empty subjects

### DIFF
--- a/controllers/clusterpermission_controller_test.go
+++ b/controllers/clusterpermission_controller_test.go
@@ -672,7 +672,7 @@ var _ = Describe("ClusterPermission controller", func() {
 				},
 			}))).Should(Equal(1))
 
-			By("Create ClusterPermission with ClusterRoleBinding that has no subject or subjects")
+			By("Create ClusterPermission with ClusterRoleBinding that has no subject or subjects - should be rejected by XValidation")
 			clusterPermissionMissingSubjectSubjects := cpv1alpha1.ClusterPermission{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "clusterpermission-no-subject-subjects",
@@ -690,7 +690,7 @@ var _ = Describe("ClusterPermission controller", func() {
 				},
 			}
 
-			Expect(k8sClient.Create(ctx, &clusterPermissionMissingSubjectSubjects)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, &clusterPermissionMissingSubjectSubjects)).ShouldNot(Succeed())
 
 			By("Create ClusterPermission with Role and ClusterRole that doesn't exist validate should have error status")
 			clusterPermissionRoleClusterRoleNotExistValidate := cpv1alpha1.ClusterPermission{


### PR DESCRIPTION
## Summary

- **Fixed** unit test that incorrectly expected `k8sClient.Create()` to succeed for a `ClusterPermission` with an empty `subjects` slice in its `ClusterRoleBinding`
- The CRD already has a CEL XValidation rule (`has(self.subject) || has(self.subjects)`) that rejects ClusterRoleBindings without subjects
- With newer envtest versions (K8s 1.31+), the API server correctly enforces this validation, causing the test to fail
- Updated the assertion from `Should(Succeed())` to `ShouldNot(Succeed())` to match the expected behavior

## Root Cause

The `Subjects` field uses `json:"subjects,omitempty"`, so an empty slice `[]rbacv1.Subject{}` is omitted during JSON serialization. This means `has(self.subjects)` returns `false` in CEL evaluation, and since `Subject` is also nil, the XValidation rule correctly rejects the create request.

Previously, the test passed because older K8s versions (1.24) used in envtest did not enforce CEL XValidation rules on CRDs.

## Test plan

- [x] Verify `make test` passes with the fix (2 Passed, 0 Failed)
- [x] Confirmed the same fix is needed on `release-2.16` branch (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)