### PR TITLE
feat: migrate cluster-permission from ACM to MCE build

### DIFF
--- a/.tekton/cluster-permission-mce-217-pull-request.yaml
+++ b/.tekton/cluster-permission-mce-217-pull-request.yaml
@@ -4,16 +4,17 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/cluster-permission?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: release-acm-217
-    appstudio.openshift.io/component: cluster-permission-acm-217
+    appstudio.openshift.io/application: release-mce-217
+    appstudio.openshift.io/component: cluster-permission-mce-217
     pipelines.appstudio.openshift.io/type: build
-  name: cluster-permission-acm-217-on-push
+  name: cluster-permission-mce-217-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -22,7 +23,9 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-permission-acm-217:{{revision}}
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-permission-mce-217:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: build-platforms
     value:
     - linux/x86_64
@@ -33,12 +36,6 @@ spec:
     value: Dockerfile.rhtap
   - name: path-context
     value: .
-  - name: send-slack-notification
-    value: 'true'
-  - name: konflux-application-name
-    value: release-acm-217
-  - name: slack-member-id
-    value: UUSRGGQ1L
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
   pipelineRef:
@@ -51,7 +48,7 @@ spec:
     - name: pathInRepo
       value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cluster-permission-acm-217
+    serviceAccountName: build-pipeline-cluster-permission-mce-217
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cluster-permission-mce-217-push.yaml
+++ b/.tekton/cluster-permission-mce-217-push.yaml
@@ -4,17 +4,16 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/cluster-permission?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "main"
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: release-acm-217
-    appstudio.openshift.io/component: cluster-permission-acm-217
+    appstudio.openshift.io/application: release-mce-217
+    appstudio.openshift.io/component: cluster-permission-mce-217
     pipelines.appstudio.openshift.io/type: build
-  name: cluster-permission-acm-217-on-pull-request
+  name: cluster-permission-mce-217-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -23,9 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-permission-acm-217:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-permission-mce-217:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -36,6 +33,12 @@ spec:
     value: Dockerfile.rhtap
   - name: path-context
     value: .
+  - name: send-slack-notification
+    value: 'true'
+  - name: konflux-application-name
+    value: release-mce-217
+  - name: slack-member-id
+    value: UUSRGGQ1L
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "."}, {"type": "rpm", "path": "."}]'
   pipelineRef:
@@ -48,7 +51,7 @@ spec:
     - name: pathInRepo
       value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cluster-permission-acm-217
+    serviceAccountName: build-pipeline-cluster-permission-mce-217
   workspaces:
   - name: git-auth
     secret:

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -16,9 +16,9 @@ ENV OPERATOR=/usr/local/bin/cluster-permission \
     USER_NAME=cluster-permission
 
 LABEL \
-    name="rhacm2/acm-cluster-permission-rhel9" \
+    name="multicluster-engine/cluster-permission-rhel9" \
     com.redhat.component="cluster-permission" \
-    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.11::el9" \
     description="Cluster permission controller" \
     maintainer="acm-contact@redhat.com" \
     io.k8s.description="Cluster permission controller" \


### PR DESCRIPTION
## Summary

Migrate cluster-permission component from ACM (Advanced Cluster Management) to MCE (Multicluster Engine) build pipeline.

### Changes

- **`.tekton/`**: Renamed pipeline files from `acm-217` to `mce-217`, updated application label (`release-mce-217`), component name (`cluster-permission-mce-217`), output image paths, and service account names
- **`Dockerfile.rhtap`**: Updated image name from `rhacm2/acm-cluster-permission-rhel9` to `multicluster-engine/cluster-permission-rhel9`, CPE from `acm:2.16` to `multicluster_engine:2.11`

### Companion PR

- openshift/release CI config migration: https://github.com/openshift/release/pull/76512

🤖 Generated with [Claude Code](https://claude.com/claude-code)