### PR TITLE
fix: [acm-217] cluster-permission-acm-217 - Konflux compliance failure

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -18,7 +18,7 @@ ENV OPERATOR=/usr/local/bin/cluster-permission \
 LABEL \
     name="rhacm2/acm-cluster-permission-rhel9" \
     com.redhat.component="cluster-permission" \
-    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    cpe="cpe:/a:redhat:acm:2.17::el9" \
     description="Cluster permission controller" \
     maintainer="acm-contact@redhat.com" \
     io.k8s.description="Cluster permission controller" \


### PR DESCRIPTION
## Bug
https://redhat.atlassian.net/browse/ACM-31505

## Root Cause
The Konflux build for acm-217 is failing Enterprise Contract compliance because the CPE label in Dockerfile.rhtap on the release-2.17 branch is outdated. It is currently set to `cpe:/a:redhat:acm:2.16::el9` instead of matching the 2.17 release.

## Fix
Update the cpe label in Dockerfile.rhtap to `cpe="cpe:/a:redhat:acm:2.17::el9"` on the release-2.17 branch.

## Auto-generated
This draft PR was automatically generated by server-foundation-agent based on bug triage analysis.
**Human review is required before merging.**

Co-Authored-By: server-foundation-agent <noreply@redhat.com>