### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,39 @@
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS plugin-builder
+
+WORKDIR /go/src/github.com/open-cluster-management-io/cluster-permission
+COPY . .
+RUN rm -fr vendor && \
+        go mod vendor && \
+        CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make -f Makefile build
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+RUN microdnf update -y && \
+     microdnf clean all
+
+ENV OPERATOR=/usr/local/bin/cluster-permission \
+    USER_UID=1001 \
+    USER_NAME=cluster-permission
+
+LABEL \
+    name="rhacm2/acm-cluster-permission-rhel9" \
+    com.redhat.component="cluster-permission" \
+    cpe="cpe:/a:redhat:acm:2.16::el9" \
+    description="Cluster permission controller" \
+    maintainer="acm-contact@redhat.com" \
+    io.k8s.description="Cluster permission controller" \
+    org.label-schema.license="Red Hat Advanced Cluster Management for Kubernetes EULA" \
+    org.label-schema.schema-version="1.0" \
+    summary="Cluster permission controller" \
+    io.k8s.display-name="Cluster permission" \
+    io.openshift.tags="mce acm cluster-permission"
+
+# install operator binary
+COPY --from=plugin-builder /go/src/github.com/open-cluster-management-io/cluster-permission/bin/cluster-permission /usr/local/bin/cluster-permission
+
+COPY build/bin /usr/local/bin
+RUN  /usr/local/bin/user_setup
+
+ENTRYPOINT ["/usr/local/bin/entrypoint"]
+
+USER ${USER_UID}


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)