### PR TITLE
Add FIPS build flags to Dockerfile

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -4,7 +4,7 @@ WORKDIR /go/src/github.com/open-cluster-management-io/cluster-permission
 COPY . .
 RUN rm -fr vendor && \
         go mod vendor && \
-        make -f Makefile build
+        CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make -f Makefile build
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 


### PR DESCRIPTION
Add CGO_ENABLED=1 and GOEXPERIMENT=strictfipsruntime to go build, make, and promu build lines for FIPS compliance.

JIRA: HYPBLD-847