### PR TITLE
:seedling: Sync with upstream open-cluster-management-io/cluster-permission (Go 1.26)

### DIFF
--- a/.github/workflows/chart-upload.yml
+++ b/.github/workflows/chart-upload.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: get release version

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Run FOSSA Scan
         uses: fossas/fossa-action@v1
         with:

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'CHANGELOG/**'
+      - 'LICENSE'
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GOPATH: '/home/runner/work/cluster-permission/cluster-permission/go'
 defaults:

--- a/.github/workflows/go-postsubmit.yml
+++ b/.github/workflows/go-postsubmit.yml
@@ -26,18 +26,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
           path: go/src/github.com/open-cluster-management/cluster-permission
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: test
         run: make test
       - name: report-coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           files: /home/runner/work/cluster-permission/cluster-permission/go/src/github.com/open-cluster-management/cluster-permission/coverage.out
@@ -51,12 +51,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
           path: go/src/github.com/open-cluster-management/cluster-permission
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'CHANGELOG/**'
+      - 'LICENSE'
 
 env:
   # Common versions

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -15,6 +15,7 @@ env:
   # Common versions
   GO_VERSION: '1.25'
   GO_REQUIRED_MIN_VERSION: ''
+  KUBERNETES_VERSION: 'v1.32.2'
   GOPATH: '/home/runner/work/cluster-permission/cluster-permission/go'
 defaults:
   run:
@@ -26,12 +27,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
           path: go/src/github.com/open-cluster-management/cluster-permission
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: pre-build
@@ -44,12 +45,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
           path: go/src/github.com/open-cluster-management/cluster-permission
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -62,18 +63,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
           path: go/src/github.com/open-cluster-management/cluster-permission
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: test
         run: make test
       - name: report-coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: /home/runner/work/cluster-permission/cluster-permission/go/src/github.com/open-cluster-management/cluster-permission/coverage.out
@@ -89,9 +90,9 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@caf8857bbd3276599d0176b0528e9712bb0b5bec # master
         with:
           args: -exclude-generated ./...
         env:
@@ -101,28 +102,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 1
           path: go/src/github.com/open-cluster-management/cluster-permission
       - name: install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
         run: go install github.com/openshift/imagebuilder/cmd/imagebuilder@v1.2.3
       - name: images
         run: make docker-build
-      - name: setup kind
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: v0.27.0
-          name: cluster1
-      - name: setup kind
-        uses: engineerd/setup-kind@v0.5.0
-        with:
-          version: v0.27.0
-          name: hub
+      - name: setup kind cluster1
+        run: kind create cluster --name cluster1 --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
+      - name: setup kind hub
+        run: kind create cluster --name hub --image kindest/node:${{ env.KUBERNETES_VERSION }} --wait 300s
       - name: Load image on the nodes of the cluster
         run: |
           kind load docker-image --name=hub quay.io/open-cluster-management/cluster-permission:latest

--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   KUBERNETES_VERSION: 'v1.32.2'
   GOPATH: '/home/runner/work/cluster-permission/cluster-permission/go'

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
       - name: install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install imagebuilder
@@ -35,7 +35,7 @@ jobs:
         run: |
           echo "MAJOR_RELEASE_VERSION=${RELEASE_VERSION%.*}" >> $GITHUB_ENV
       - name: setup helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
       - name: chart package
         run: |
           mkdir -p release
@@ -53,7 +53,7 @@ jobs:
           echo "- See the [CHANGELOG](https://github.com/open-cluster-management-io/cluster-permission/blob/main/CHANGELOG/CHANGELOG-${MAJOR_RELEASE_VERSION}.md) for more details." >> /home/runner/work/changelog.txt
           echo "- The released image is quay.io/open-cluster-management/cluster-permission:$RELEASE_VERSION" >> /home/runner/work/changelog.txt
       - name: publish release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*.*.*'
 env:
   # Common versions
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   GO_REQUIRED_MIN_VERSION: ''
   GITHUB_REF: ${{ github.ref }}
   CHART_NAME: cluster-permission

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ These files exist ONLY in the downstream fork and must be preserved during syncs
 - **`Dockerfile.rhtap`** -- RHTAP/Konflux-oriented container build
 - **`COMPONENT_NAME`** -- Downstream component naming for builds
 - **`rpms.in.yaml`** / **`rpms.lock.yaml`** -- RPM lock inputs for Konflux/cachi2-style builds
-- **`OWNERS`** -- May have additional temporary approvers compared to upstream
+- **`OWNERS`** -- The downstream OWNERS lists the Red Hat ACM team, which is entirely different from the upstream community maintainers. Always preserve the stolostron version during syncs.
 
 ## Downstream-Only Commits
 
@@ -98,6 +98,8 @@ Resolution strategy:
 - For dependencies that exist in both repos: **take upstream's version** (source of truth)
 - For downstream-only dependencies (rare): keep them
 - Downstream-only files (`.tekton/`, `renovate.json`, etc.) should rarely conflict; keep the downstream copies
+- **`OWNERS`**: always keep the stolostron/downstream version -- the Red Hat team is entirely
+  different from the upstream community maintainers. Use `git checkout --ours OWNERS` to resolve.
 
 To resolve conflicts manually:
 
@@ -129,7 +131,80 @@ If **vendor/** is present in your branch, after resolving modules run:
 go mod vendor
 ```
 
-### Step 5: Verify downstream-only files
+### Step 5: Verify vendor integrity and build
+
+After resolving all conflicts, run these two commands to catch any remaining
+issues (e.g. leftover conflict markers in vendor files that `git add` won't
+detect, or files that `go mod vendor` would add/remove):
+
+```bash
+# Re-sync dependencies and vendor directory
+make deps
+
+# Confirm the code compiles cleanly and passes linting
+make lint
+```
+
+If `make deps` produces changes (e.g. updated `go.sum` or vendor files), stage and amend them into the merge commit
+before continuing. If `make lint` fails, trace the error back to the conflicted
+file and fix it.
+
+Also verify that no upstream commits were lost in the merge:
+
+```bash
+# upstream/main must be a reachable ancestor of your branch HEAD
+git merge-base --is-ancestor upstream/main HEAD && echo "OK - all upstream commits preserved" || echo "ERROR - upstream commits missing!"
+
+# Should print nothing (no commits in upstream that aren't in your branch)
+git log --oneline upstream/main --not HEAD
+```
+
+### Step 6: Update the RHTAP Dockerfile
+
+`Dockerfile.rhtap` is a downstream-only file that parallels the upstream `Dockerfile`. During a
+sync, first check whether the upstream `Dockerfile` was modified by any of the incoming commits:
+
+```bash
+git log --oneline upstream/main --not HEAD~ -- Dockerfile
+```
+
+If upstream changed its `Dockerfile` (new build stages, added dependencies, changed `COPY`/`RUN`
+instructions, etc.), evaluate whether `Dockerfile.rhtap` needs equivalent updates. The two files
+intentionally differ -- `Dockerfile.rhtap` uses Red Hat builder/runtime images and includes Red Hat
+`LABEL` blocks -- but structural build logic changes often need to be mirrored manually.
+
+If the upstream sync includes a **Go version bump** (check `go.mod` for a changed `go` directive),
+the RHTAP Dockerfile must also be updated manually -- it is downstream-only and won't be touched by
+the merge.
+
+```bash
+# Check current Go version in go.mod
+go list -m -json go
+
+# Check current version in the RHTAP Dockerfile
+grep -i "^FROM .* AS builder$" Dockerfile.rhtap
+```
+
+Update the builder FROM image tag in `Dockerfile.rhtap` to match the Go version in `go.mod` (e.g. `rhel_9_1.25` -> `rhel_9_1.26`):
+
+The builder image tag pattern is `rhel_<rhel-version>_<go-version>`, e.g.:
+
+```
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS builder
+```
+
+Note: the runtime base image (`ubi9/ubi-minimal`) and Red Hat `LABEL` blocks in `Dockerfile.rhtap`
+are intentionally different from the upstream Dockerfile and should **not** be changed to match
+upstream.
+
+Commit the Dockerfile change separately:
+
+```bash
+git add Dockerfile.rhtap
+git commit -s -S -m "chore: upgrade RHTAP Dockerfile to Go <version>"
+```
+
+### Step 7: Verify downstream-only files
 
 After resolving conflicts, verify these files still exist and are correct:
 
@@ -143,14 +218,18 @@ test -f rpms.in.yaml && test -f rpms.lock.yaml && echo RPM lockfiles OK
 cat OWNERS
 ```
 
-### Step 6: Commit and push
+### Step 8: Commit and push
 
 ```bash
-git commit -m "Sync with upstream open-cluster-management-io/cluster-permission $(date +%Y-%m-%d)"
+git commit -s -S -m "Sync with upstream open-cluster-management-io/cluster-permission $(date +%Y-%m-%d)"
 git push origin sync-upstream-$(date +%Y%m%d)
 ```
 
 Then create a PR on GitHub targeting `main`.
+
+**Important:** When merging the PR, always use **"Create a merge commit"** -- not squash or
+rebase. This preserves the original upstream commit SHAs in the downstream history, making
+future syncs and divergence checks accurate.
 
 ## Handling Manual/Urgent Cherry-Picks
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/stolostron/builder:go1.25-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.26-linux AS builder
 
 WORKDIR /go/src/github.com/open-cluster-management-io/cluster-permission
 COPY . .

--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS plugin-builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.26 AS plugin-builder
 
 WORKDIR /go/src/github.com/open-cluster-management-io/cluster-permission
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module open-cluster-management.io/cluster-permission
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
## Summary

Syncs `stolostron/cluster-permission` with 5 new commits from `open-cluster-management-io/cluster-permission` main, bringing in the Go 1.26 upgrade, pinned GitHub Actions, and a CLAUDE.md symlink change.

## Upstream commits included

- `chore: pin GitHub Actions to digest SHAs and replace setup-kind`
- `:seedling: chore: upgrade to go 1.26`
- Merge commits for upstream PRs #89, #90, #91

Note: upstream PR #89 (`unify-readme-claude-symlink-v2`) converted `CLAUDE.md` to a symlink pointing to `README.md`. The downstream preserves `CLAUDE.md` as a regular file containing sync instructions.

## Downstream-only changes

- **`docs: update CLAUDE.md with RHTAP Dockerfile, OWNERS, and merge commit steps`** -- adds OWNERS conflict resolution guidance, Step 5 (vendor integrity + upstream commit verification), Step 6 (RHTAP Dockerfile Go version update), renumbers steps, adds merge commit reminder

## Conflict resolution

- `CLAUDE.md`: upstream changed to symlink -> kept downstream regular file (contains sync instructions not in README.md)
- `go.mod`, `Dockerfile`, `Dockerfile.rhtap`: auto-merged (Go 1.25 -> 1.26, dep bumps, pinned actions)
- `OWNERS`: no conflict (upstream did not touch it in these commits)

## Verification

- `git merge-base --is-ancestor upstream/main HEAD` -> OK
- `git log --oneline upstream/main --not HEAD` -> (empty, all commits preserved)
- `go build ./...` -> clean

**When merging: please use "Create a merge commit" (not squash or rebase) to preserve upstream commit SHAs.**