### PR TITLE
Sync with upstream open-cluster-management-io/cluster-permission 2026-07-27

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,9 @@
 approvers:
 - elgnay
+- mikeshng
 
 emeritus_approvers:
 - lennysgarage
 - fxiang1
-- mikeshng
 - philipwu08
 - xiangjingli

--- a/chart/templates/cluster-permission-networkpolicy.yaml
+++ b/chart/templates/cluster-permission-networkpolicy.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.networkPolicies.enabled }}
+# Purpose: Default-deny for cluster-permission controller, then allow DNS and
+# Kubernetes API egress. Metrics ingress (:8286) is allowed when NetworkPolicies
+# are enabled. Peers are port-based (empty "to"/"from") for portability across
+# Kubernetes vendors. Health probes use exec (ls), so no health ingress port.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: cluster-permission-network-policy
+spec:
+  podSelector:
+    matchLabels:
+      name: cluster-permission
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8286
+  egress:
+  # DNS (:53 common; :5353 used by some distributions)
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    - protocol: UDP
+      port: 5353
+    - protocol: TCP
+      port: 5353
+  # Kubernetes API
+  - ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 6443
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,3 +11,10 @@ hubconfig:
   replicaCount: 1
   tolerations: []
 org: open-cluster-management
+
+# Opt-in NetworkPolicy for the hub cluster-permission controller.
+# Default false so community installs are unchanged. Policies use port-based
+# peers for portability across Kubernetes vendors. Metrics ingress (:8286) is
+# opened when enabled.
+networkPolicies:
+  enabled: false


### PR DESCRIPTION
## Summary

Sync `stolostron/cluster-permission` with upstream [`open-cluster-management-io/cluster-permission`](https://github.com/open-cluster-management-io/cluster-permission) (was 3 commits behind).

Supersedes the cross-fork Sync fork PR https://github.com/stolostron/cluster-permission/pull/314 (conflicts could not be resolved on upstream `main` as the PR head).

### Upstream commits included

- `708a88b` / `4ac60ea` — Add `mikeshng` as approver ([upstream #92](https://github.com/open-cluster-management-io/cluster-permission/pull/92))
- `f8e6498` — Opt-in NetworkPolicy for the hub cluster-permission controller ([upstream #93](https://github.com/open-cluster-management-io/cluster-permission/pull/93))
  - Adds `chart/templates/cluster-permission-networkpolicy.yaml`
  - Gates on `networkPolicies.enabled` (default `false`)

### Conflict resolution

- `OWNERS` — kept downstream reviewers/approvers (already includes `mikeshng`)
- `chart/values.yaml` — kept downstream `hubconfig.ocpVersion` and added upstream `networkPolicies` block

## Test plan

- [ ] Confirm `.tekton/`, `Dockerfile.rhtap`, `renovate.json`, and other downstream-only files are unchanged
- [ ] CI: `images`, `test-unit`, `ocm-ci-rbac`, `sonarcloud`

Made with [Cursor](https://cursor.com)